### PR TITLE
enable weight file refference errors in -m predict

### DIFF
--- a/game_manager/machine_learning/block_controller_train.py
+++ b/game_manager/machine_learning/block_controller_train.py
@@ -316,31 +316,19 @@ class Block_Controller(object):
         ####################
         # 推論の場合 推論ウェイトを torch　で読み込み model に入れる。
         if self.mode=="predict" or self.mode=="predict_sample":
-            if not predict_weight=="None":
-                if os.path.exists(predict_weight):
-                    print("Load {}...".format(predict_weight))
-                    # 推論インスタンス作成
-                    self.model = torch.load(predict_weight)
-                    # インスタンスを推論モードに切り替え
-                    self.model.eval()    
-                else:
-                    print("{} is not existed!!".format(predict_weight))
-                    exit()
-            else:
-                print("Please set predict_weight!!")
-                exit()
+            print("Load {}...".format(predict_weight))
+            # 推論インスタンス作成
+            self.model = torch.load(predict_weight)
+            # インスタンスを推論モードに切り替え
+            self.model.eval()
 
             ## 第2 model
             if self.weight2_available and (not predict_weight2=="None"):
-                if os.path.exists(predict_weight2):
-                    print("Load2 {}...".format(predict_weight2))
-                    # 推論インスタンス作成
-                    self.model2 = torch.load(predict_weight2)
-                    # インスタンスを推論モードに切り替え
-                    self.model2.eval()    
-                else:
-                    print("{} is not existed!!(predict 2)".format(predict_weight))
-                    exit()
+                print("Load2 {}...".format(predict_weight2))
+                # 推論インスタンス作成
+                self.model2 = torch.load(predict_weight2)
+                # インスタンスを推論モードに切り替え
+                self.model2.eval()
 
         ####################
         #### finetune の場合

--- a/game_manager/machine_learning/block_controller_train_sample.py
+++ b/game_manager/machine_learning/block_controller_train_sample.py
@@ -105,17 +105,9 @@ class Block_Controller(object):
             self.reward_weight = cfg["train"]["reward_weight"]
 
         if self.mode=="predict" or self.mode=="predict_sample":
-            if not predict_weight=="None":
-                if os.path.exists(predict_weight):
-                    print("Load {}...".format(predict_weight))
-                    self.model = torch.load(predict_weight)
-                    self.model.eval()    
-                else:
-                    print("{} is not existed!!".format(predict_weight))
-                    exit()
-            else:
-                print("Please set predict_weight!!")
-                exit()
+            print("Load {}...".format(predict_weight))
+            self.model = torch.load(predict_weight)
+            self.model.eval()
         elif cfg["model"]["finetune"]:
             self.ft_weight = cfg["common"]["ft_weight"]
             if not self.ft_weight is None:

--- a/game_manager/machine_learning/block_controller_train_sample2.py
+++ b/game_manager/machine_learning/block_controller_train_sample2.py
@@ -104,19 +104,10 @@ class Block_Controller(object):
             self.reward_func = self.step_v2
             self.reward_weight = cfg["train"]["reward_weight"]
 
-
         if self.mode=="predict" or self.mode=="predict_sample" or self.mode == "predict_sample2":
-            if not predict_weight=="None":
-                if os.path.exists(predict_weight):
-                    print("Load {}...".format(predict_weight))
-                    self.model = torch.load(predict_weight)
-                    self.model.eval()    
-                else:
-                    print("{} is not existed!!".format(predict_weight))
-                    exit()
-            else:
-                print("Please set predict_weight!!")
-                exit()
+            print("Load {}...".format(predict_weight))
+            self.model = torch.load(predict_weight)
+            self.model.eval() 
         elif cfg["model"]["finetune"]:
             self.ft_weight = cfg["common"]["ft_weight"]
             if not self.ft_weight is None:

--- a/start.py
+++ b/start.py
@@ -187,10 +187,9 @@ def start():
         + ' ' + '--BlockNumMax' + ' ' + str(BLOCK_NUM_MAX) \
         + ' ' + '--art_config_filepath' + ' ' + str(ART_CONFIG)
 
-    ret = subprocess.run(cmd, shell=True)
+    ret = subprocess.run(cmd, shell=True, capture_output=True, text=True)
     if ret.returncode != 0:
-        print('error: subprocess failed.', file=sys.stderr)
-        sys.exit(1)
+        raise Exception(ret.stderr)
     #p = subprocess.Popen(cmd, shell=True)
     #try:
     #    p.wait()


### PR DESCRIPTION
#110 
現状
ファイル存在チェックによってエラーを回避しているがゆえにエラーを吐かずにプロセスが死んでいる

変更後
あえてファイル存在チェックをせずにエラーを出させる

考え方
```
現状考えられるエラーケースとして、
1. ファイルが見つからない
2. ファイルがあっても中身が不適切でloadできない
3. ？？？
がある
全部について自分でチェックするよりかは、全部torch.loadが発するエラーに任せてしまった方がいいんじゃないか？
```
