### PR TITLE
Add over3_diff_penalty to DQN reward

### DIFF
--- a/config/default.yaml
+++ b/config/default.yaml
@@ -68,6 +68,8 @@ train:
   hole_top_limit_height: 5 # 穴の上の積み上げペナルティ下限絶対高さ、この高さより上のときのみペナルティ有効 (22: 無効, -1:制限なし)
   hole_top_limit: 1 # 穴の上の積み上げペナルティ 穴の位置が左記の相対高さより高いときのみ
 
+  over3_diff_penalty: 0.01 # 左端以外で3段以上の段差を作った場合のペナルティ
+
   move_down_flag: 0 # Move Down 有効化 #DQN限定
 
   #predict_next_flag: 1 # 次のテトリミノ予測有効化 # 20220831 無効


### PR DESCRIPTION
tetris盤面の左端以外の列で3段以上の段差を作った場合、rewardを減点するようにする。
Iミノ以外で回復できない盤面になりにくくする意図がある。