### PR TITLE
fix stdout setting in start.py

### DIFF
--- a/start.py
+++ b/start.py
@@ -187,7 +187,7 @@ def start():
         + ' ' + '--BlockNumMax' + ' ' + str(BLOCK_NUM_MAX) \
         + ' ' + '--art_config_filepath' + ' ' + str(ART_CONFIG)
 
-    ret = subprocess.run(cmd, shell=True, capture_output=True, text=True)
+    ret = subprocess.run(cmd, shell=True, stderr=subprocess.PIPE, text=True)
     if ret.returncode != 0:
         raise Exception(ret.stderr)
     #p = subprocess.Popen(cmd, shell=True)


### PR DESCRIPTION
https://github.com/seigot/tetris/pull/112#issuecomment-1546937288

【症状】
テトリスの標準出力が表示されない

【原因】
capture_output=trueにしていたため
start.pyから呼び出す子プロセスの標準出力をその場で表示できていなかった

【対処方法】
subprocess.run()のオプションを変更。エラーのみを受け取れるようにstderr=PIPEに変更