### PR TITLE
docker-composeファイルの修正

### DIFF
--- a/docker-compose.pytorch.yaml
+++ b/docker-compose.pytorch.yaml
@@ -1,16 +1,16 @@
-version: '1'
+version: '3'
 
 services:
   tetris:
-    container_name: tetris-container
+    container_name: tetris-pytorch-container
     build:
       context: .
       dockerfile: ./docker/Dockerfile.pytorch
     volumes:
       - type: bind
-        source: "."
-        target: "/tetris"
+        source: .
+        target: /tetris
     environment:
-    - DISPLAY=host.docker.internal:0.0
+      - DISPLAY=host.docker.internal:0.0
     tty: true
     shm_size: 512m


### PR DESCRIPTION
`docker compose`時に以下のエラーが出るので修正
```
$docker-compose -f docker-compose.pytorch.yaml up
ERROR: Version in ".\docker-compose.pytorch.yaml" is invalid. You might be seeing this error because you're using the wrong Compose file version. Either specify a supported version (e.g "2.2" or "3.3") and place your service definitions under the `services` key, or omit the `version` key and place your service definitions at the root of the file to use version 1.
For more on the Compose file format versions, see https://docs.docker.com/compose/compose-file/
```